### PR TITLE
make singletons globally available

### DIFF
--- a/src/models/GlobalRegistry.ts
+++ b/src/models/GlobalRegistry.ts
@@ -1,0 +1,8 @@
+import Global = NodeJS.Global;
+import {StepRegistry} from "./StepRegistry";
+import {HookRegistry} from "./HookRegistry";
+
+export interface GlobalStepRegistry extends Global {
+    gaugeStepRegistry: StepRegistry,
+    gaugeHookRegistry: HookRegistry
+}

--- a/src/models/HookRegistry.ts
+++ b/src/models/HookRegistry.ts
@@ -1,6 +1,7 @@
 import { Operator } from "..";
 import { HookMethod } from "./HookMethod";
 import { HookType } from "./HookType";
+import {GlobalStepRegistry} from "./GlobalRegistry";
 
 export class HookRegistry {
 
@@ -69,7 +70,11 @@ export class HookRegistry {
     }
 
 }
+declare const global: GlobalStepRegistry;
 
-const hookRegistry = new HookRegistry();
+if (!global.gaugeHookRegistry) {
+    global.gaugeHookRegistry = new HookRegistry();
+}
+const hookRegistry = global.gaugeHookRegistry;
 
 export default hookRegistry;

--- a/src/models/StepRegistry.ts
+++ b/src/models/StepRegistry.ts
@@ -1,7 +1,8 @@
-import { AssertionError } from "assert";
-import { Range } from './Range';
-import { StepRegistryEntry } from "./StepRegistryEntry";
+import {AssertionError} from "assert";
+import {Range} from './Range';
+import {StepRegistryEntry} from "./StepRegistryEntry";
 import {CommonFunction} from '../utils/Util';
+import {GlobalStepRegistry} from "./GlobalRegistry";
 
 export class StepRegistry {
 
@@ -113,6 +114,11 @@ export class StepRegistry {
 
 }
 
-const registry = new StepRegistry();
+declare const global: GlobalStepRegistry;
+
+if (!global.gaugeStepRegistry) {
+    global.gaugeStepRegistry = new StepRegistry();
+}
+const registry = global.gaugeStepRegistry;
 
 export default registry;

--- a/src/stores/DataStoreFactory.ts
+++ b/src/stores/DataStoreFactory.ts
@@ -1,21 +1,32 @@
 import { DataStore } from "./DataStore";
+import {GlobalDataStore} from "./GlobalDataStore";
+
+declare const global: GlobalDataStore;
 
 export class DataStoreFactory {
 
-    private static readonly _suiteDataStore: DataStore = new DataStore();
-    private static readonly _specDataStore: DataStore = new DataStore();
-    private static readonly _scenarioDataStore: DataStore = new DataStore();
-
     public static getSuiteDataStore(): DataStore {
-        return this._suiteDataStore;
+        if (!global.gaugeSuiteDataStore) {
+            global.gaugeSuiteDataStore = new DataStore();
+        }
+
+        return global.gaugeSuiteDataStore;
     }
 
     public static getSpecDataStore(): DataStore {
-        return this._specDataStore;
+        if (!global.gaugeSpecDataStore) {
+            global.gaugeSpecDataStore = new DataStore();
+        }
+
+        return global.gaugeSpecDataStore;
     }
 
     public static getScenarioDataStore(): DataStore {
-        return this._scenarioDataStore;
+        if (!global.gaugeScenarioDataStore) {
+            global.gaugeScenarioDataStore = new DataStore();
+        }
+
+        return global.gaugeScenarioDataStore;
     }
 
 }

--- a/src/stores/GlobalDataStore.ts
+++ b/src/stores/GlobalDataStore.ts
@@ -1,0 +1,8 @@
+import Global = NodeJS.Global;
+import {DataStore} from "./DataStore";
+
+export interface GlobalDataStore extends Global {
+    gaugeSpecDataStore: DataStore,
+    gaugeSuiteDataStore: DataStore,
+    gaugeScenarioDataStore: DataStore,
+}


### PR DESCRIPTION
Hi!
Happy new year.
thanks for the great work you've done here. While extending my test setup and split up into different modules I noticed a, most-likely, unwanted behaviour.

Imagine a setup where you have multiple module containing steps and others using those modules. This would result in a dependency tree like this:

> * Test Module A
>   * gauge-ts
>   * Shared-Steps Module A
>     * gauge-ts
>   * Shared-Steps Module B
>     * gauge-ts
> * Test Module B
>   * gauge-ts
>   * Shared-Steps Module A
>     * gauge-ts
> * Test Module C
>   * gauge-ts
>   * Shared-Steps Module B
>     * gauge-ts

Since `npm` by default doesn't flatten the dependancy tree you have now up to 3 installations of `gauge-ts`. The StepRegistry, HookRegistry and the DataStores are initialised in every of those modules and are singleton independent of each other. The decorator implementations save e.g. the Step instances only in the StepRegistry of the direct dependant module. This eventually leads to the fact that, if you run Test Module A, steps from module Shared-Steps Module A & B cannot be found after starting the tests. since it only uses the StepRegistry of Test Module A/gauge-ts.

The validation step doesn't fail in this moment, since it actually can see all the Step implementations.

However, this patch is pretty rough using `global` but would guarantee only one instance of a StepRegistry being used.