### PR TITLE
build: remove trusted publishing hack

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
+          check-latest: true
 
       - name: Install dependencies
         run: |
@@ -37,6 +38,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: true
 
       - name: Install dependencies
         run: |
@@ -59,6 +61,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
+          check-latest: true
 
       - name: Create artifact
         run: |
@@ -87,6 +90,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: true
 
       - name: npm dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
+          check-latest: true
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup git
@@ -34,7 +35,6 @@ jobs:
         run: |
           npm run build
           ./build.sh package
-
 
       - name: Deploy on github
         working-directory: gauge-ts
@@ -54,8 +54,7 @@ jobs:
 
       - name: Deploy npm
         working-directory: gauge-ts
-        run: | # See https://github.com/actions/setup-node/issues/1440
-          unset NODE_AUTH_TOKEN
+        run: |
           npm publish --access=public
 
       - name: Update metadata in gauge-repository


### PR DESCRIPTION
The workaround seems no longer necessary now. Also ensures running with latest patch node; mainly to ensure latest stable npm is in use for publishing.