### PR TITLE
Allow configuring the package runner used by the launcher

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,24 @@ Once the initialization is done run `npm install` to get all the required depend
 Now you can run `gauge run specs` to run your project.
 Open the project in your favorite editor and start adding some new tests.
 
+### Configure the package runner
+
+By default, gauge-ts starts `ts-node` with `npx`. To use the package manager
+configured for your project, set `GAUGE_TS_PACKAGE_RUNNER` to one of `npm`,
+`pnpm`, `yarn`, or `bun`. For example, in a Gauge environment properties file:
+
+```properties
+GAUGE_TS_PACKAGE_RUNNER = pnpm
+```
+
+The corresponding commands are `npm exec --`, `pnpm exec`, `yarn exec`, and
+`bun x`. You can also set the value to `npx` explicitly.
+
+The selected package runner must be available on `PATH` in the environment
+where Gauge is started.
+
+The `yarn` option targets modern Yarn releases (Yarn 2 and later).
+
 
 ## APIS
 

--- a/gauge-ts/build.ps1
+++ b/gauge-ts/build.ps1
@@ -22,6 +22,7 @@ $tasks.Add('package', @{
             npm run clean:build
             mkdir -p deploy
             Copy-Item launcher.* deploy
+            Copy-Item launcher-runner.cjs deploy
             Copy-Item ts.json deploy
             mkdir artifacts
             $version = version

--- a/gauge-ts/build.sh
+++ b/gauge-ts/build.sh
@@ -24,7 +24,7 @@ function package() {
     checkCommand "zip"
     npm run clean:build
     mkdir -p deploy
-    cp launcher.* deploy
+    cp launcher.* launcher-runner.cjs deploy
     cp ts.json deploy
     mkdir -p artifacts
     (export version=$(version) && cd deploy && zip -r ../artifacts/gauge-ts-$version.zip .)

--- a/gauge-ts/launcher-runner.cjs
+++ b/gauge-ts/launcher-runner.cjs
@@ -1,0 +1,23 @@
+const PACKAGE_RUNNERS = Object.freeze({
+  npx: ["npx"],
+  npm: ["npm", "exec", "--"],
+  pnpm: ["pnpm", "exec"],
+  yarn: ["yarn", "exec"],
+  bun: ["bun", "x"],
+});
+
+function getPackageRunner(value = process.env.GAUGE_TS_PACKAGE_RUNNER) {
+  const name = value ?? "npx";
+  const runner = PACKAGE_RUNNERS[name];
+
+  if (!runner) {
+    throw new Error(
+      `Unsupported GAUGE_TS_PACKAGE_RUNNER: ${JSON.stringify(name)}. ` +
+        `Supported values: ${Object.keys(PACKAGE_RUNNERS).join(", ")}`,
+    );
+  }
+
+  return runner;
+}
+
+module.exports = { getPackageRunner };

--- a/gauge-ts/launcher.mjs
+++ b/gauge-ts/launcher.mjs
@@ -11,6 +11,9 @@ if (Number.parseInt(version[0]) < 20) {
 }
 
 import { spawn } from "node:child_process";
+import launcherRunner from "./launcher-runner.cjs";
+
+const { getPackageRunner } = launcherRunner;
 
 const { GAUGE_PROJECT_ROOT } = process.env;
 
@@ -24,20 +27,26 @@ function hasModule(name) {
 }
 
 function startCommand() {
+  const useShell = process.platform === "win32";
+  const shellQuote = useShell ? '"' : "";
+
   const opts = [
     "ts-node",
     "--esm",
     "-r",
     "tsconfig-paths/register",
     "-e",
-    `"import { start } from 'gauge-ts/dist/RunnerServer'; start();"`,
+    `${shellQuote}import { start } from 'gauge-ts/dist/RunnerServer'; start();${shellQuote}`,
   ];
 
-  const runner = spawn("npx", opts, {
+  const [command, ...runnerArgs] = getPackageRunner();
+  const runner = spawn(command, [...runnerArgs, ...opts], {
     env: process.env,
     silent: false,
     stdio: "inherit",
-    shell: true,
+    // Package-manager shims are .cmd files on Windows and require cmd.exe.
+    // `command` is safe to pass to the shell because it comes from a fixed map.
+    shell: useShell,
     cwd: GAUGE_PROJECT_ROOT,
   });
   runner.on("error", (err) => {

--- a/gauge-ts/package.json
+++ b/gauge-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gauge-ts",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Typescript runner for Gauge",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/gauge-ts/tests/LauncherTests.ts
+++ b/gauge-ts/tests/LauncherTests.ts
@@ -1,0 +1,23 @@
+const { getPackageRunner } = require("../launcher-runner.cjs");
+
+describe("launcher package runner", () => {
+  test.each([
+    [undefined, ["npx"]],
+    ["npx", ["npx"]],
+    ["npm", ["npm", "exec", "--"]],
+    ["pnpm", ["pnpm", "exec"]],
+    ["yarn", ["yarn", "exec"]],
+    ["bun", ["bun", "x"]],
+  ])("maps %p to %p", (value, expected) => {
+    expect(getPackageRunner(value)).toEqual(expected);
+  });
+
+  test.each(["", "pnpm exec", '["pnpm", "exec"]', "custom-runner"])(
+    "rejects unsupported value %p",
+    (value) => {
+      expect(() => getPackageRunner(value)).toThrow(
+        `Unsupported GAUGE_TS_PACKAGE_RUNNER: ${JSON.stringify(value)}`,
+      );
+    },
+  );
+});

--- a/gauge-ts/ts.json
+++ b/gauge-ts/ts.json
@@ -16,6 +16,6 @@
     "linux": ["./launcher.mjs", "--start"],
     "windows": ["launcher.bat", "--start"]
   },
-  "version": "0.4.0",
+  "version": "0.5.0",
   "gRPCSupport": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       }
     },
     "gauge-ts": {
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.4",


### PR DESCRIPTION
## Summary

- Add `GAUGE_TS_PACKAGE_RUNNER` to select the package runner used to invoke `ts-node`
- Support `npx`, `npm`, `pnpm`, `yarn`, and `bun`
- Continue using `npx` when the variable is not set
- Reject unsupported values instead of accepting arbitrary commands or arguments
- Document the configuration and add unit tests
- Include the package-runner helper in Unix and Windows plugin packages

## Implementation

The environment variable accepts a runner name rather than an arbitrary command:

```properties
GAUGE_TS_PACKAGE_RUNNER = pnpm
```

Each supported value is mapped internally:

- `npx` → `npx`
- `npm` → `npm exec --`
- `pnpm` → `pnpm exec`
- `yarn` → `yarn exec`
- `bun` → `bun x`

This prevents `GAUGE_TS_PACKAGE_RUNNER` from supplying arbitrary commands or additional arguments.

On Linux and macOS, the runner is spawned with `shell: false`.

On Windows, package-manager commands are commonly exposed through `.cmd` shims. Testing `npx` with `shell: false` resulted in `ENOENT`, while directly spawning `npx.cmd` resulted in `EINVAL`. The launcher therefore retains shell execution on Windows so that `cmd.exe` can execute these shims.

The command passed to the Windows shell still comes from the fixed internal mapping rather than directly from the environment variable.

The mapping is intentionally limited to package runners. Other execution modes, such as native TypeScript support, can be introduced later as explicit options if needed.

## Testing

- Added unit tests for every supported runner mapping
- Added tests for empty, argv-style, and unsupported values
- All gauge-ts tests pass: 145 passed, 1 skipped
- Biome checks pass for the changed implementation and test files
- Installed the generated plugin in an isolated Gauge environment on Windows
- Verified Gauge execution with:
  - Default `npx`
  - `npm exec`
  - pnpm 11.8.0
  - Yarn 4.17.0 with Plug'n'Play
  - Bun 1.3.14
- Verified that unsupported runner values fail with an explicit error

Closes #212