### PR TITLE
fix: conditionally load tsconfig-paths

### DIFF
--- a/gauge-ts/launcher-runner.cjs
+++ b/gauge-ts/launcher-runner.cjs
@@ -20,4 +20,16 @@ function getPackageRunner(value = process.env.GAUGE_TS_PACKAGE_RUNNER) {
   return runner;
 }
 
-module.exports = { getPackageRunner };
+function getTsNodeArgs({ hasTsconfigPaths, useShell }) {
+  const shellQuote = useShell ? '"' : "";
+
+  return [
+    "ts-node",
+    "--esm",
+    ...(hasTsconfigPaths ? ["-r", "tsconfig-paths/register"] : []),
+    "-e",
+    `${shellQuote}import { start } from 'gauge-ts/dist/RunnerServer'; start();${shellQuote}`,
+  ];
+}
+
+module.exports = { getPackageRunner, getTsNodeArgs };

--- a/gauge-ts/launcher.mjs
+++ b/gauge-ts/launcher.mjs
@@ -13,7 +13,7 @@ if (Number.parseInt(version[0]) < 20) {
 import { spawn } from "node:child_process";
 import launcherRunner from "./launcher-runner.cjs";
 
-const { getPackageRunner } = launcherRunner;
+const { getPackageRunner, getTsNodeArgs } = launcherRunner;
 
 const { GAUGE_PROJECT_ROOT } = process.env;
 
@@ -28,16 +28,10 @@ function hasModule(name) {
 
 function startCommand() {
   const useShell = process.platform === "win32";
-  const shellQuote = useShell ? '"' : "";
-
-  const opts = [
-    "ts-node",
-    "--esm",
-    "-r",
-    "tsconfig-paths/register",
-    "-e",
-    `${shellQuote}import { start } from 'gauge-ts/dist/RunnerServer'; start();${shellQuote}`,
-  ];
+  const opts = getTsNodeArgs({
+    hasTsconfigPaths: hasModule("tsconfig-paths"),
+    useShell,
+  });
 
   const [command, ...runnerArgs] = getPackageRunner();
   const runner = spawn(command, [...runnerArgs, ...opts], {

--- a/gauge-ts/package.json
+++ b/gauge-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gauge-ts",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Typescript runner for Gauge",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/gauge-ts/tests/LauncherTests.ts
+++ b/gauge-ts/tests/LauncherTests.ts
@@ -1,4 +1,4 @@
-const { getPackageRunner } = require("../launcher-runner.cjs");
+const { getPackageRunner, getTsNodeArgs } = require("../launcher-runner.cjs");
 
 describe("launcher package runner", () => {
   test.each([
@@ -20,4 +20,36 @@ describe("launcher package runner", () => {
       );
     },
   );
+});
+
+describe("ts-node arguments", () => {
+  test("preloads tsconfig-paths when it is installed", () => {
+    expect(getTsNodeArgs({ hasTsconfigPaths: true, useShell: false })).toEqual([
+      "ts-node",
+      "--esm",
+      "-r",
+      "tsconfig-paths/register",
+      "-e",
+      "import { start } from 'gauge-ts/dist/RunnerServer'; start();",
+    ]);
+  });
+
+  test("does not preload tsconfig-paths when it is not installed", () => {
+    expect(getTsNodeArgs({ hasTsconfigPaths: false, useShell: false })).toEqual(
+      [
+        "ts-node",
+        "--esm",
+        "-e",
+        "import { start } from 'gauge-ts/dist/RunnerServer'; start();",
+      ],
+    );
+  });
+
+  test("quotes the eval script when using a shell", () => {
+    const args = getTsNodeArgs({ hasTsconfigPaths: false, useShell: true });
+
+    expect(args.at(-1)).toBe(
+      "\"import { start } from 'gauge-ts/dist/RunnerServer'; start();\"",
+    );
+  });
 });

--- a/gauge-ts/ts.json
+++ b/gauge-ts/ts.json
@@ -16,6 +16,6 @@
     "linux": ["./launcher.mjs", "--start"],
     "windows": ["launcher.bat", "--start"]
   },
-  "version": "0.5.0",
+  "version": "0.5.1",
   "gRPCSupport": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       }
     },
     "gauge-ts": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.4",


### PR DESCRIPTION
## Summary

- preload `tsconfig-paths/register` only when `tsconfig-paths` is installed in the Gauge project
- preserve path-alias support for projects that declare `tsconfig-paths`
- move the `ts-node` argument construction into a testable launcher helper
- add regression coverage for projects with and without `tsconfig-paths`

## Validation

- `npm test --workspace gauge-ts -- --runInBand`
  - 29 test suites passed
  - 148 tests passed, 1 skipped
- `npm run build --workspace gauge-ts`
- Biome checks on the changed implementation and test files
- installed the generated gauge-ts 0.5.0 plugin under an isolated `GAUGE_HOME`
- ran the Gauge e2e project successfully:
  - 2 specifications passed
  - 4 scenarios passed

Closes #215