### PR TITLE
fix(genproto): remove noise comments and clean output dir before regen

### DIFF
--- a/gauge-ts/genproto.sh
+++ b/gauge-ts/genproto.sh
@@ -1,23 +1,16 @@
 set -eu
-# ponytail: dropped pipefail because the script has no pipelines and dash (Ubuntu /bin/sh) rejects it.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Auto-init submodule if .proto files are missing (e.g. fresh clone without --recurse-submodules)
 if [ ! -f "$SCRIPT_DIR/../gauge-proto/messages.proto" ]; then
   git -C "$SCRIPT_DIR/.." submodule update --init gauge-proto
 fi
 
-# Run protoc from the script directory with relative paths so the Windows
-# protoc.exe binary doesn't choke on MSYS-style /d/a/... paths from Git Bash
-# (MSYS heuristics skip args like --js_out=/d/a/...). Relative paths are not
-# translated, so protoc sees the same shape on every platform.
 cd "$SCRIPT_DIR"
 PROTO_DIR="../gauge-proto"
 OUTPUT_DIR="src/gen"
 
-# Non-destructive: let protoc overwrite per-file. Avoids wiping the output dir
-# before protoc runs, which previously left the working copy empty on failure.
+rm -rf "$OUTPUT_DIR"
 mkdir -p "$OUTPUT_DIR"
 
 grpc_tools_node_protoc \


### PR DESCRIPTION
Addresses review comments on #222:

- Remove `# ponytail:` comment (noise referencing deleted code)
- Remove unverified Windows/MSYS comment block
- Replace non-destructive `mkdir -p` with `rm -rf` + `mkdir -p` to ensure stale generated files are cleaned up when proto definitions are removed