### PR TITLE
chore: upgrade TypeScript to v6

### DIFF
--- a/gauge-ts/package.json
+++ b/gauge-ts/package.json
@@ -19,12 +19,7 @@
     "type": "git",
     "url": "git+https://github.com/getgauge/gauge-ts.git"
   },
-  "keywords": [
-    "gauge",
-    "Acceptance Test",
-    "Typescript",
-    "Automation"
-  ],
+  "keywords": ["gauge", "Acceptance Test", "Typescript", "Automation"],
   "author": "Gauge <getgauge@outlook.com>",
   "license": "MIT",
   "bugs": {

--- a/gauge-ts/package.json
+++ b/gauge-ts/package.json
@@ -19,7 +19,12 @@
     "type": "git",
     "url": "git+https://github.com/getgauge/gauge-ts.git"
   },
-  "keywords": ["gauge", "Acceptance Test", "Typescript", "Automation"],
+  "keywords": [
+    "gauge",
+    "Acceptance Test",
+    "Typescript",
+    "Automation"
+  ],
   "author": "Gauge <getgauge@outlook.com>",
   "license": "MIT",
   "bugs": {
@@ -29,7 +34,7 @@
     "@bufbuild/protobuf": "^2.12.1",
     "@grpc/grpc-js": "^1.14.4",
     "ts-node": "^10.9.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "@biomejs/biome": "1.7.3",

--- a/gauge-ts/tsconfig.json
+++ b/gauge-ts/tsconfig.json
@@ -7,7 +7,8 @@
     "outDir": "./dist",
     "strict": true,
     "skipLibCheck": true,
-    "moduleResolution": "node",
+    "rootDir": "./src",
+    "moduleResolution": "bundler",
     "plugins": [
       {
         "cacheBetweenTests": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@bufbuild/protobuf": "^2.12.1",
         "@grpc/grpc-js": "^1.14.4",
         "ts-node": "^10.9.0",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       },
       "devDependencies": {
         "@biomejs/biome": "1.7.3",
@@ -86,6 +86,19 @@
       "license": "MIT",
       "dependencies": {
         "jest-diff": "^24.3.0"
+      }
+    },
+    "gauge-ts/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
## Summary

Upgrades TypeScript from `^5.9.3` to `^6.0.3`.

## Changes

- **`gauge-ts/package.json`** — bump `typescript` dependency to `^6.0.3`
- **`gauge-ts/tsconfig.json`** — add explicit `rootDir: "./src"` (now required in TS6) and switch `moduleResolution` from `"node"` to `"bundler"` (`node10` was removed in TS6)
- **`package-lock.json`** — updated lock file

## Testing

All 148 tests pass, 1 skipped by design.

> Note: TypeScript 7 was also evaluated but it removes the Compiler API entirely, making it incompatible with this project's runtime use of the TypeScript AST for step definition parsing. TypeScript 6 is the appropriate upgrade target.

Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>